### PR TITLE
Feat: personalized theme

### DIFF
--- a/src/.vuepress/config.ts
+++ b/src/.vuepress/config.ts
@@ -5,9 +5,24 @@ import theme from "./theme.js";
 export default defineUserConfig({
   base: "/",
 
-  lang: "en-US",
-  title: "Docs Demo",
-  description: "A docs demo for vuepress-theme-hope",
+  lang: "fr-FR",
+  title: "MyECL - ÉCLAIR",
+  description: "La doc de MyECL...",
+
+  head: [
+    ["link", { rel: "preconnect", href: "https://fonts.googleapis.com" }],
+    [
+      "link",
+      { rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: "" },
+    ],
+    [
+      "link",
+      {
+        href: "https://fonts.googleapis.com/css2?family=Cascadia+Code:ital,wght@0,200..700;1,200..700&display=swap",
+        rel: "stylesheet",
+      },
+    ],
+  ],
 
   theme,
 

--- a/src/.vuepress/navbar.ts
+++ b/src/.vuepress/navbar.ts
@@ -2,10 +2,13 @@ import { navbar } from "vuepress-theme-hope";
 
 export default navbar([
   "/",
+  "/git/",
   "/hyperion/",
+  "/titan/",
+  "/metadocs/",
   {
     text: "Github",
     icon: "github",
-    link: "https://github.com/orgs/aeecleclair/",
+    link: "https://github.com/aeecleclair/",
   },
 ]);

--- a/src/.vuepress/sidebar.ts
+++ b/src/.vuepress/sidebar.ts
@@ -1,14 +1,3 @@
 import { sidebar } from "vuepress-theme-hope";
 
-export default sidebar({
-  "/": [
-    "",
-    {
-      text: "Hyperion",
-      icon: "laptop-code",
-      prefix: "hyperion/",
-      link: "hyperion/",
-      children: "structure",
-    },
-  ],
-});
+export default sidebar("structure");

--- a/src/.vuepress/styles/config.scss
+++ b/src/.vuepress/styles/config.scss
@@ -1,2 +1,2 @@
 // you can change config here
-$theme-color: #096dd9;
+$theme-color: #fb7c05;

--- a/src/.vuepress/styles/palette.scss
+++ b/src/.vuepress/styles/palette.scss
@@ -1,1 +1,2 @@
 // you can change colors here
+$vp-font-mono: '"Cascadia Code"';

--- a/src/.vuepress/theme.ts
+++ b/src/.vuepress/theme.ts
@@ -4,14 +4,14 @@ import navbar from "./navbar.js";
 import sidebar from "./sidebar.js";
 
 export default hopeTheme({
-  hostname: "https://aeecleclair.github.io/myecl-documentation/",
+  hostname: "https://docs.myecl.fr",
 
   author: {
     name: "Aeecleclair",
-    url: "https://github.com/orgs/aeecleclair/",
+    url: "https://github.com/aeecleclair/",
   },
 
-  logo: "https://theme-hope-assets.vuejs.press/logo.svg",
+  logo: "/common/logoeclair.svg",
 
   repo: "vuepress-theme-hope/vuepress-theme-hope",
 
@@ -23,7 +23,7 @@ export default hopeTheme({
   // sidebar
   sidebar,
 
-  footer: "Default footer",
+  footer: "Cuisiné par ÉCLAIR",
 
   displayFooter: true,
 
@@ -111,7 +111,6 @@ export default hopeTheme({
   },
 
   plugins: {
-
     components: {
       components: ["Badge", "VPCard"],
     },
@@ -119,6 +118,7 @@ export default hopeTheme({
     icon: {
       prefix: "fa6-solid:",
     },
+    readingTime: { wordPerMinute: 150 },
 
     // install @vuepress/plugin-pwa and uncomment these if you want a PWA
     // pwa: {

--- a/src/README.md
+++ b/src/README.md
@@ -7,16 +7,26 @@ bgImage: https://theme-hope-assets.vuejs.press/bg/6-light.svg
 bgImageDark: https://theme-hope-assets.vuejs.press/bg/6-dark.svg
 bgImageStyle:
   background-attachment: fixed
-heroText: Project name
-tagline: You can place the description of the project here.
+heroText: Documentation MyECL
+tagline: L'application pour l'associatif centralien, développée par ÉCLAIR
 actions:
-  - text: How to Use
-    icon: lightbulb
-    link: ./demo/
+  - text: Git
+    #icon: lightbulb
+    link: ./git/
+
+  - text: Hyperion
+    #icon: lightbulb
+    link: ./hyperion/
     type: primary
 
-  - text: Docs
-    link: ./guide/
+  - text: Titan
+    #icon: lightbulb
+    link: ./titan/
+    type: primary
+
+  - text: Méta-docs
+    #icon: lightbulb
+    link: ./metadocs/
 
 highlights:
   - header: Easy to install

--- a/src/hyperion/README.md
+++ b/src/hyperion/README.md
@@ -1,6 +1,5 @@
 ---
 title: Hyperion
-icon: laptop-code
 category:
   - Guide
 ---


### PR DESCRIPTION
* French locale
* Home page title and description
* *Cascadia Code* font for code blocks: for ligatures (it's more readable)
* Complete the navbar and use ÉCLAIR's logo
* Fix GitHub link for the org
* Use ÉCLAIR's signature orange
* Decrease words per minute from default 300 to 150 (benchmarked together with @warix8)